### PR TITLE
path/fs.existsSync is deprecated - use fs.access instead

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ var server=http.createServer(function (req, res) {
     if(pending[key]) pending[key].end();
     pending[key]=res;
   }  
-  else if(path.existsSync(key) && fs.statSync(key).isFile() && key.indexOf("..")==-1)
+  else if(fs.access(key, fs.F_OK | fs.R_OK) && fs.statSync(key).isFile() && key.indexOf("..")==-1)
   {
     res.setHeader("Content-Type", "text/html");
     var instream=fs.createReadStream(key);


### PR DESCRIPTION
ref:
 https://nodejs.org/api/fs.html#fs_fs_existssync_path

Signed-off-by: Maximilian Güntner <maximilian.guentner@gmail.com>