### PR TITLE
Removed obsolete DOM nesting

### DIFF
--- a/ui.css
+++ b/ui.css
@@ -266,24 +266,24 @@
       display: block;
     }
     /* hide default parameters in effects selection list*/
-    #effects .key, #effects .value div:not(:first-child){
+    #effects .key, #effects div:not(:first-child){
       display: none;
     }
-    .effect>.ui_object>.value{
+    .effect{
       margin-left: 0px;
     }
     .effect>.ui_object>.key
     {
       display: none;
     }
-    .effect>.ui_object>.value>:first-child{
+    .effect>:first-child{
       display: block;
     }    
-    .effect>.ui_object>.value>:first-child>.key
+    .effect>:first-child>.key
     {
       display: none;
     }
-    .effect>.ui_object>.value>:first-child>.value
+    .effect>:first-child>.value
     {
       font-size: 16px;
     }
@@ -311,7 +311,7 @@
       content: '▾';
     }
     /* effects with more inputs show additional stack input arrows.*/
-    .chain .effect[ui_inputs="2"]>.ui_object::before{
+    .chain .effect[ui_inputs="2"]>:first-child::before{
       display: block;
       position:absolute;
       top: -3px;
@@ -319,7 +319,7 @@
       content: '◂▤';
       color: #f00;
     }
-    .chain .effect[ui_inputs="3"]>.ui_object::before{
+    .chain .effect[ui_inputs="3"]>:first-child::before{
       display: block;
       position:absolute;
       top: -3px;
@@ -332,7 +332,7 @@
       display: none;
     }
     /* effects with additional outputs show stack output arrows*/
-    .chain .effect[ui_outputs]>.ui_object::before{
+    .chain .effect[ui_outputs]>:last-child::before{
       display: block;
       position:absolute;
       bottom: -3px;
@@ -425,21 +425,21 @@
     }    
 
     /* nestet UI blocks, like multiple slider BEAT or OSC UIs */
-    .ui_object .ui_object
+    .ui_object
     {
 	    background-color: #373737;
 	    margin: 2px;
 	    border-radius:2px;
 	    box-shadow: 2px 2px 2px 0px rgba(0,0,0,.3);
     }
-    .adjust_ui .ui_object .ui_object{      
+    .adjust_ui .ui_object{
       border-radius: 5px;
       margin: 5px;
       padding-left: 15px;
       background-color: #333;
       box-shadow: 2px 2px 8px 0px rgba(0,0,0,1);
     }
-    .adjust_ui .ui_object .ui_object .ui_object{
+    .adjust_ui .ui_object .ui_object{
       background-color: #555;
     }    
     .adjust_ui .ui_number{

--- a/ui.html
+++ b/ui.html
@@ -194,17 +194,17 @@
       return data;
     }
   
-    /* create a effect DOM, value_renderer provides the UI for a single value */
+    /* create an effect DOM, value_renderer provides the UI for a single value */
     var create_effect_element=function(effect,value_renderer)
     {
-        var li=$('<div class=effect>');
+        var li=get_ui('',effect,value_renderer).find('>span.value');
+        li.addClass('effect');
         var effect_template=effects[effect.effect];
         li.attr('ui_effect',effect.effect);
         for(key in effect_template)
           if(key!='args')
             li.attr('ui_'+key, effect_template[key]);
-        li.append(get_ui('',effect,value_renderer));
-        return li;    
+        return li;
     }
     
     /* create UI DOM for an array of effects into container  */
@@ -398,7 +398,7 @@
       }
 
       // add OSC and BEAT button to each value
-      slider_ui.find('.ui_object:not([ui_type])>.value>.ui_number>.value').each(function(){
+      slider_ui.find('>.ui_number>.value').each(function(){
         var element=$(this);
         // get value field of original value_element to manipulate by this UI
         var value_element=$(element.data('original_value_element'));
@@ -418,7 +418,7 @@
       });
       
       // the first element in a nested UI block shows it's type, so disable it.
-      slider_ui.find('.ui_object .ui_object input').first().attr('disabled',true);
+      slider_ui.find('.ui_object input').first().attr('disabled',true);
 
       // add popup container to body
       popup=create_popup('adjust_ui',effect_element,slider_ui);
@@ -465,7 +465,7 @@
         // add name to pre- or post chain. For other chains, it is done by chain token.
         if(selector=='#pre_chain' || selector=='#post_chain')
 	  chain.push($(selector).parent().find('h2').html());
-        $(selector).find('.effect>.ui_object>.value').each(function(){
+        $(selector).find('.effect').each(function(){
           var effect=get_data($(this));
           chain.push(effect);
           full_chain.push(effect);


### PR DESCRIPTION
Refined `create_effect_element` and adjusted matching selectors in jQuery and CSS to get rid of unneeded `.ui_object`, `.value containers` at `.effects` top level to reduce DOM size.